### PR TITLE
Added new feature to wire up external dependencies

### DIFF
--- a/src/Heliar.Composition.Core.Tests/ContainerBootstrapperTest.cs
+++ b/src/Heliar.Composition.Core.Tests/ContainerBootstrapperTest.cs
@@ -15,7 +15,7 @@ using System.ComponentModel.Composition;
 using System.ComponentModel.Composition.Hosting;
 using System.ComponentModel.Composition.Registration;
 using System.Diagnostics.CodeAnalysis;
-
+using System.Net.Http;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -199,6 +199,17 @@ namespace Heliar.Composition.Core.Tests
 			result.Catalog.Parts.Should().Contain(p => (p as System.ComponentModel.Composition.Primitives.ICompositionElement).DisplayName == "Heliar.Composition.Core.Tests.Foo");
 			result.Catalog.Parts.Should().Contain(p => (p as System.ComponentModel.Composition.Primitives.ICompositionElement).DisplayName == "Samples.Business.CustomerService");
 			result.Catalog.Parts.Should().Contain(p => (p as System.ComponentModel.Composition.Primitives.ICompositionElement).DisplayName == "Samples.Data.CustomerRepository");
+		}
+
+		[TestMethod]
+		public void TypesRegisteredInExternalAssemblyShouldBeCreateable()
+		{
+			var sut = new ContainerBootstrapper();
+			sut.Should().NotBeNull();
+			var container = sut.Bootstrap();
+			container.Should().NotBeNull();
+			var client = container.GetExportedValue<HttpClient>();
+			client.Should().NotBeNull();
 		}
 
 		//TODO: RLV - Write registrar finisher test(s)

--- a/src/Heliar.Composition.Core.Tests/Heliar.Composition.Core.Tests.csproj
+++ b/src/Heliar.Composition.Core.Tests/Heliar.Composition.Core.Tests.csproj
@@ -55,6 +55,7 @@
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.ComponentModel.Composition.registration" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Reflection.Context" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />

--- a/src/Heliar.Composition.Core.Tests/TestApplicationDependencyRegistrar.cs
+++ b/src/Heliar.Composition.Core.Tests/TestApplicationDependencyRegistrar.cs
@@ -15,6 +15,8 @@ using System.ComponentModel.Composition;
 using System.ComponentModel.Composition.Hosting;
 using System.ComponentModel.Composition.Registration;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Net.Http;
 
 namespace Heliar.Composition.Core.Tests
 {
@@ -36,6 +38,14 @@ namespace Heliar.Composition.Core.Tests
 				.SetCreationPolicy(CreationPolicy.NonShared)
 				.ExportInterfaces()
 				.Export();
+
+			var httpRegistrations = new RegistrationBuilder();
+			httpRegistrations.ForType<HttpClient>()
+				.SelectConstructor(ctor => { return ctor.FirstOrDefault(ci => ci.GetParameters().Length == 0); })
+				.SetCreationPolicy(CreationPolicy.NonShared)
+				.ExportInterfaces()
+				.Export();
+			catalog.Catalogs.Add(new AssemblyCatalog(typeof(HttpClient).Assembly, httpRegistrations));
 		}
 	}
 

--- a/src/Heliar.Composition.Core.Tests/TestApplicationDependencyRegistrar.cs
+++ b/src/Heliar.Composition.Core.Tests/TestApplicationDependencyRegistrar.cs
@@ -12,6 +12,7 @@
 // <summary>Dependency mocks for testing</summary>
 // ***********************************************************************
 using System.ComponentModel.Composition;
+using System.ComponentModel.Composition.Hosting;
 using System.ComponentModel.Composition.Registration;
 using System.Diagnostics.CodeAnalysis;
 
@@ -27,8 +28,9 @@ namespace Heliar.Composition.Core.Tests
 		/// <summary>
 		/// Registers the dependencies within this application.
 		/// </summary>
-		/// <param name="registrations">The registrations.</param>
-		public void Register(RegistrationBuilder registrations)
+		/// <param name="registrations">The dependency registrations/conventions to wire up.</param>
+		/// <param name="catalog">An AggregateCatalog that can be added to if dependencies reside in an external assembly, i.e. BCL.</param>
+		public void Register(RegistrationBuilder registrations, AggregateCatalog catalog)
 		{
 			registrations.ForType<Foo>()
 				.SetCreationPolicy(CreationPolicy.NonShared)

--- a/src/Heliar.Composition.Core/CatalogBootstrapper.cs
+++ b/src/Heliar.Composition.Core/CatalogBootstrapper.cs
@@ -75,14 +75,14 @@ namespace Heliar.Composition.Core
 
 				foreach (var bootstrapExport in bootstrapExports)
 				{
-					bootstrapExport.Value.Register(registrations);
+					bootstrapExport.Value.Register(registrations, this.Catalog);
 				}
 
 				var appBootstrapperExports = container.GetExports<IApplicationDependencyRegistrar>();
 				try
 				{
 					var appBootstrapper = appBootstrapperExports.Single().Value;
-					appBootstrapper.Register(registrations);
+					appBootstrapper.Register(registrations, this.Catalog);
 				}
 				catch (Exception)
 				{

--- a/src/Heliar.Composition.Core/ContainerBootstrapper.cs
+++ b/src/Heliar.Composition.Core/ContainerBootstrapper.cs
@@ -74,7 +74,7 @@ namespace Heliar.Composition.Core
 
 				foreach (var bootstrapExport in bootstrapExports)
 				{
-					bootstrapExport.Value.Register(registrations);
+					bootstrapExport.Value.Register(registrations, this.Catalog);
 				}
 
 				//TODO: RLV - Reconsider whether requiring application registrar is best approach
@@ -83,7 +83,7 @@ namespace Heliar.Composition.Core
 				if (count == 1)
 				{
 					var appBootstrapper = appBootstrapperExports.Single().Value;
-					appBootstrapper.Register(registrations);
+					appBootstrapper.Register(registrations, this.Catalog);
 				}
 				else
 				{

--- a/src/Heliar.Composition.Core/IApplicationDependencyRegistrar.cs
+++ b/src/Heliar.Composition.Core/IApplicationDependencyRegistrar.cs
@@ -26,6 +26,8 @@
 // </copyright>
 // <summary></summary>
 // ***********************************************************************
+
+using System.ComponentModel.Composition.Hosting;
 using System.ComponentModel.Composition.Registration;
 
 namespace Heliar.Composition.Core
@@ -37,9 +39,10 @@ namespace Heliar.Composition.Core
 	public interface IApplicationDependencyRegistrar
 	{
 		/// <summary>
-		/// Registers the dependencies within this application.
+		/// Registers the dependencies (via convention) within this application.
 		/// </summary>
-		/// <param name="registrations">The registrations.</param>
-		void Register(RegistrationBuilder registrations);
+		/// <param name="registrations">The dependency registrations/conventions to wire up.</param>
+		/// <param name="catalog">An AggregateCatalog that can be added to if dependencies reside in an external assembly, i.e. BCL.</param>
+		void Register(RegistrationBuilder registrations, AggregateCatalog catalog);
 	}
 }

--- a/src/Heliar.Composition.Core/ILibraryDependencyRegistrar.cs
+++ b/src/Heliar.Composition.Core/ILibraryDependencyRegistrar.cs
@@ -26,6 +26,8 @@
 // </copyright>
 // <summary></summary>
 // ***********************************************************************
+
+using System.ComponentModel.Composition.Hosting;
 using System.ComponentModel.Composition.Registration;
 
 namespace Heliar.Composition.Core
@@ -38,7 +40,8 @@ namespace Heliar.Composition.Core
 		/// <summary>
 		/// Bootstraps the dependencies within this library.
 		/// </summary>
-		/// <param name="registrations">The registrations.</param>
-		void Register(RegistrationBuilder registrations);
+		/// <param name="registrations">The dependency registrations/conventions to wire up.</param>
+		/// <param name="catalog">An AggregateCatalog that can be added to if dependencies reside in an external assembly, i.e. BCL.</param>
+		void Register(RegistrationBuilder registrations, AggregateCatalog catalog);
 	}
 }

--- a/src/Heliar.Composition.Mvc/MvcDependencyRegistrar.cs
+++ b/src/Heliar.Composition.Mvc/MvcDependencyRegistrar.cs
@@ -27,6 +27,7 @@
 // <summary></summary>
 // ***********************************************************************
 using System.ComponentModel.Composition;
+using System.ComponentModel.Composition.Hosting;
 using System.ComponentModel.Composition.Registration;
 using System.Web.Mvc;
 
@@ -43,13 +44,12 @@ namespace Heliar.Composition.Mvc
 		/// <summary>
 		/// Adds the necessary registrations to perform composition for MVC.
 		/// </summary>
-		/// <remarks>
-		/// Note that many MVC types like filters are composed by
+		/// <param name="registrations">The dependency registrations/conventions to wire up.</param>
+		/// <param name="catalog">An AggregateCatalog that can be added to if dependencies reside in an external assembly, i.e. BCL.</param>
+		/// <remarks>Note that many MVC types like filters are composed by
 		/// custom providers and not the stock resolver and therefore aren't
-		/// configured here.
-		/// </remarks>
-		/// <param name="registrations">The registrations.</param>
-		public void Register(RegistrationBuilder registrations)
+		/// configured here.</remarks>
+		public void Register(RegistrationBuilder registrations, AggregateCatalog catalog)
 		{
 			registrations.ForTypesDerivedFrom<IController>()
 				.SetCreationPolicy(CreationPolicy.NonShared)

--- a/src/Heliar.Composition.WebApi/WebApiDependencyRegistrar.cs
+++ b/src/Heliar.Composition.WebApi/WebApiDependencyRegistrar.cs
@@ -49,8 +49,9 @@ namespace Heliar.Composition.WebApi
 		/// <summary>
 		/// Adds necessary composition registrations to perform composition for WebAPI.
 		/// </summary>
-		/// <param name="registrations">The registrations.</param>
-		public void Register(RegistrationBuilder registrations)
+		/// <param name="registrations">The dependency registrations/conventions to wire up.</param>
+		/// <param name="catalog">An AggregateCatalog that can be added to if dependencies reside in an external assembly, i.e. BCL.</param>
+		public void Register(RegistrationBuilder registrations, AggregateCatalog catalog)
 		{
 			registrations.ForTypesDerivedFrom<IHttpController>()
 				.SetCreationPolicy(CreationPolicy.NonShared)

--- a/src/Samples.Business/BusinessDependencyRegistrar.cs
+++ b/src/Samples.Business/BusinessDependencyRegistrar.cs
@@ -15,7 +15,7 @@ namespace Samples.Business
 	[ExcludeFromCodeCoverage]
 	public class BusinessDependencyRegistrar : ILibraryDependencyRegistrar
 	{
-		public void Register(RegistrationBuilder registrations)
+		public void Register(RegistrationBuilder registrations, AggregateCatalog catalog)
 		{
 			registrations.ForTypesMatching(t => t.Name.EndsWith("Service"))
 				.SetCreationPolicy(CreationPolicy.Shared)

--- a/src/Samples.Console/ConsoleDependencyRegistrar.cs
+++ b/src/Samples.Console/ConsoleDependencyRegistrar.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.Composition;
+using System.ComponentModel.Composition.Hosting;
 using System.ComponentModel.Composition.Registration;
 using System.Diagnostics.CodeAnalysis;
 
@@ -18,7 +19,7 @@ namespace Samples.ConsoleApp
 		/// Registers the dependencies within this application.
 		/// </summary>
 		/// <param name="registrations">The registrations.</param>
-		public void Register(RegistrationBuilder registrations)
+		public void Register(RegistrationBuilder registrations, AggregateCatalog catalog)
 		{
 			registrations.ForTypesDerivedFrom<ILogger>()
 				.SetCreationPolicy(CreationPolicy.Shared)

--- a/src/Samples.Data/DataDependencyRegistrar.cs
+++ b/src/Samples.Data/DataDependencyRegistrar.cs
@@ -10,7 +10,12 @@ namespace Samples.Data
 	[ExcludeFromCodeCoverage]
 	public class DataDependencyRegistrar : ILibraryDependencyRegistrar
 	{
-		public void Register(RegistrationBuilder registrations)
+		/// <summary>
+		/// Bootstraps the dependencies within this library.
+		/// </summary>
+		/// <param name="registrations">The dependency registrations/conventions to wire up.</param>
+		/// <param name="catalog">An AggregateCatalog that can be added to if dependencies reside in an external assembly, i.e. BCL.</param>
+		public void Register(RegistrationBuilder registrations, AggregateCatalog catalog)
 		{
 			registrations.ForTypesMatching(t => t.Name.EndsWith("Repository"))
 				.SetCreationPolicy(CreationPolicy.Shared)

--- a/src/Samples.MvcApp/SampleApplicationRegistrar.cs
+++ b/src/Samples.MvcApp/SampleApplicationRegistrar.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using System.ComponentModel.Composition.Hosting;
 using System.ComponentModel.Composition.Registration;
 using System.Linq;
 using System.Reflection.Context;
@@ -13,7 +14,12 @@ namespace Samples.MvcApp
 {
 	public class SampleApplicationRegistrar : IApplicationDependencyRegistrar
 	{
-		public void Register(RegistrationBuilder registrations)
+		/// <summary>
+		/// Registers the dependencies (via convention) within this application.
+		/// </summary>
+		/// <param name="registrations">The dependency registrations/conventions to wire up.</param>
+		/// <param name="catalog">An AggregateCatalog that can be added to if dependencies reside in an external assembly, i.e. BCL.</param>
+		public void Register(RegistrationBuilder registrations, AggregateCatalog catalog)
 		{
 			registrations.ForTypesDerivedFrom<ILogger>()
 				.SetCreationPolicy(CreationPolicy.Shared)


### PR DESCRIPTION
Added functionality to allow implementors of ILibraryDependencyRegistrars and IApplicationDependencyRegistrars to wire up dependencies outside of the current assembly.